### PR TITLE
Use codepoints from ecdhe_private_use range

### DIFF
--- a/draft-kiefer-tls-ecdhe-sidh.md
+++ b/draft-kiefer-tls-ecdhe-sidh.md
@@ -225,7 +225,7 @@ The new codepoint for the "Supported Groups Registry" is:
 
     enum {
         ...,
-        x25519sidh503(0x0105), x448sidh751(0x0106),
+        x25519sidh503(0xFE00), x448sidh751(0xFE01),
     } NamedGroup;
 
 


### PR DESCRIPTION
Use of codepoints starting from 0x0100 for hybrid ECDHE-SIDH key
exchange is inconsistent with Section 2 of RFC 7919.

Instead we should use codepoints that are reserved for private use as
per RFC 8446). Namely 0xFE00 for X25519-SIDHp503 and 0xFE01 for
X448-SIDHp751.

Fixes #10